### PR TITLE
add aws-sdk-ec2instanceconnect gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       activerecord (~> 7.0)
       activesupport (~> 7.0)
       aws-sdk-ec2
+      aws-sdk-ec2instanceconnect
       aws-sdk-iam
       aws-sdk-s3
       bcrypt
@@ -134,6 +135,9 @@ GEM
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
     aws-sdk-ec2 (1.362.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-ec2instanceconnect (1.27.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-iam (1.74.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -217,6 +217,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'aws-sdk-ec2'
   spec.add_runtime_dependency 'aws-sdk-iam'
 
+  # AWS session support
+  spec.add_runtime_dependency 'aws-sdk-ec2instanceconnect'
+
   # Needed for WebSocket Support
   spec.add_runtime_dependency 'faye-websocket'
   spec.add_runtime_dependency 'eventmachine'


### PR DESCRIPTION
Adds `aws-sdk-ec2instanceconnect ` to the required gem bundle.