### PR TITLE
Add enum ec2 notes

### DIFF
--- a/modules/auxiliary/cloud/aws/enum_ec2.rb
+++ b/modules/auxiliary/cloud/aws/enum_ec2.rb
@@ -21,7 +21,12 @@ class MetasploitModule < Msf::Auxiliary
           'Aaron Soto <aaron.soto@rapid7.com>',
           'RageLtMan <rageltman[at]sempervictus>'
         ],
-        'License' => MSF_LICENSE
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'SideEffects' => [IOC_IN_LOGS],
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/cloud/aws/enum_ec2.rb
+++ b/modules/auxiliary/cloud/aws/enum_ec2.rb
@@ -40,14 +40,6 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  def handle_aws_errors(err)
-    if err.class.module_parents.include?(Aws)
-      fail_with(Failure::UnexpectedReply, err.message)
-    else
-      raise err
-    end
-  end
-
   def enumerate_regions
     return [datastore['REGION']] if datastore['REGION']
 
@@ -147,7 +139,7 @@ class MetasploitModule < Msf::Auxiliary
   rescue Seahorse::Client::NetworkingError => e
     print_error e.message
     print_error 'Confirm region name (eg. us-west-2) is valid or blank before retrying'
-  rescue ::Exception => e
-    handle_aws_errors(e)
+  rescue Aws::EC2::Errors::ServiceError => e
+    fail_with(Failure::UnexpectedReply, e.message)
   end
 end


### PR DESCRIPTION
update notes metadata newly required for lint processing

also updates error handling remove overzealous rescue and follow [official EC2 sdk documentation](https://github.com/aws/aws-sdk-ruby/blob/a350a9cf9946aadd1292df6936aecd706c6ddd85/gems/aws-sdk-ec2/lib/aws-sdk-ec2.rb#L68-L72)