### PR TITLE
Pr/collab/17430

### DIFF
--- a/documentation/modules/auxiliary/cloud/aws/enum_ssm.md
+++ b/documentation/modules/auxiliary/cloud/aws/enum_ssm.md
@@ -1,0 +1,52 @@
+## Vulnerable Application
+
+Provided AWS credentials, this module will call the authenticated API of Amazon Web Services to list all SSM-enabled EC2
+instances accessible to the account. Once enumerated as SSM-enabled, the instances can be controlled using out-of-band
+WebSocket sessions provided by the AWS API (nominally, privileged out of the box). This module provides not only the API
+enumeration identifying EC2 instances accessible via SSM with given credentials, but enables session initiation for all
+identified targets (without requiring target-level credentials) using the CreateSession mixin option. The module also
+provides an EC2 ID filter and a limiting throttle to prevent session stampedes or expensive messes.
+
+## Verification Steps
+
+1. Obtain AWS access keys
+2. Start msfconsole
+3. Set the `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `REGION`
+4. Run the module, see EC2 instances
+
+## Options
+
+## LIMIT
+Only return the specified number of results from each region.
+
+## FILTER_EC2_ID
+Look for specific EC2 instance ID.
+
+## REGION
+AWS Region (e.g. "us-west-2").
+
+## Advanced Options
+
+### CreateSession
+
+Create a new session for every successful login.
+
+## Scenarios
+
+Enumerating EC2 instances in the US-East-2 region and opening a session on each one (`CreateSession` is True).
+
+```
+msf6 auxiliary(cloud/aws/enum_ssm) > set ACCESS_KEY_ID AKIAO5WK2W9TMZT7EAM5
+ACCESS_KEY_ID => AKIAO5WK2W9TMZT7EAM5
+msf6 auxiliary(cloud/aws/enum_ssm) > set SECRET_ACCESS_KEY pDNhoEPuubvWSsp18axjPFBM4sNme6vnNUFb6qWo
+SECRET_ACCESS_KEY => pDNhoEPuubvWSsp18axjPFBM4sNme6vnNUFb6qWo
+msf6 auxiliary(cloud/aws/enum_ssm) > run
+
+[*] Checking us-east-2...
+[+] Found AWS SSM host i-02cd668d50587bdcf (ip-172-31-42-215.us-east-2.compute.internal) - 172.31.42.215
+[*] AWS SSM command shell session 3 opened (192.168.250.134:39005 -> 172.31.42.215:0) at 2023-05-22 16:43:03 -0400
+[+] Found AWS SSM host i-074187bde1453613a (EC2AMAZ-HM7U6TS.WORKGROUP) - 172.31.44.170
+[*] AWS SSM command shell session 4 opened (192.168.250.134:37231 -> 172.31.44.170:0) at 2023-05-22 16:43:05 -0400
+[*] Auxiliary module execution completed
+msf6 auxiliary(cloud/aws/enum_ssm) > 
+```

--- a/lib/msf/base/sessions/aws_ssm_command_shell_bind.rb
+++ b/lib/msf/base/sessions/aws_ssm_command_shell_bind.rb
@@ -43,7 +43,7 @@ module Msf::Sessions
           @session_type = 'shell'
         when 'Windows'
           @platform = 'windows'
-          @session_type = 'powershell'
+          @session_type = 'powershell:winpty'
           extend(Msf::Sessions::PowerShell::Mixin)
         end
 

--- a/lib/msf/base/sessions/aws_ssm_command_shell_bind.rb
+++ b/lib/msf/base/sessions/aws_ssm_command_shell_bind.rb
@@ -23,6 +23,10 @@ module Msf::Sessions
     #
     include Msf::Session::Provider::SingleCommandShell
 
+    def abort_foreground_supported
+      false
+    end
+
     def shell_command_token_unix(cmd, timeout=10)
       res = super
 
@@ -59,7 +63,7 @@ module Msf::Sessions
       if @platform == 'linux'
         # The session from SSM-SessionManagerRunShell starts with a TTY which breaks the post API so change the settings
         # and make it behave in a way consistent with other shell sessions
-        shell_command('stty -echo cbreak;pipe=$(mktemp -u);mkfifo -m 600 $pipe;cat $pipe & sh 1>$pipe 2>$pipe')
+        shell_command('stty -echo cbreak;pipe=$(mktemp -u);mkfifo -m 600 $pipe;cat $pipe & sh 1>$pipe 2>$pipe; rm $pipe; exit')
       end
 
       super

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -406,7 +406,7 @@ Shell Banner:
     print_line("Usage: download [src] [dst]")
     print_line
     print_line("Downloads remote files to the local machine.")
-    print_line("This command does not support to download a FOLDER yet")
+    print_line("Only files are supported.")
     print_line
   end
 
@@ -432,6 +432,9 @@ Shell Banner:
     # Write file to local machine
     File.binwrite(dst, content)
     print_good("Done")
+
+  rescue NotImplementedError => e
+    print_error(e.message)
   end
 
   def cmd_upload_help
@@ -468,6 +471,9 @@ Shell Banner:
       elog(e)
       return
     end
+
+  rescue NotImplementedError => e
+    print_error(e.message)
   end
 
   def cmd_source_help
@@ -792,6 +798,8 @@ protected
   end
 
   def _file_transfer
+    raise NotImplementedError.new('Session does not support file transfers.') if @session_type.ends_with?(':winpty')
+
     FileTransfer.new(self)
   end
 end

--- a/lib/msf/core/handler/bind_aws_ssm.rb
+++ b/lib/msf/core/handler/bind_aws_ssm.rb
@@ -120,7 +120,7 @@ module BindAwsSsm
   end
   #
   # Returns the handler specific string representation, in this case
-  # 'bind_tcp'.
+  # 'bind_aws_ssm'.
   #
   def self.handler_type
     return 'bind_aws_ssm'

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -49,6 +49,12 @@ module Msf::PostMixin
       # for its platform, capabilities, etc.
       check_for_session_readiness if session.type == "meterpreter"
 
+      if session.type.ends_with?(':winpty')
+        raise Msf::OptionValidateError.new({
+          'SESSION' => 'Session does not support post modules.'
+        })
+      end
+
       incompatibility_reasons = session_incompatibility_reasons(session)
       if incompatibility_reasons.any?
         print_warning("SESSION may not be compatible with this module:")

--- a/lib/rex/proto/http/web_socket.rb
+++ b/lib/rex/proto/http/web_socket.rb
@@ -37,7 +37,6 @@ module Rex::Proto::Http::WebSocket
       # @!attribute [r] params
       #   @return [Rex::Socket::Parameters]
       attr_reader :params
-      # Boolean flag to control frame masking on output
 
       # @param [WebSocket::Interface] websocket the WebSocket that this channel is being opened on
       # @param [nil, Symbol] read_type the data type(s) to read from the WebSocket, one of :binary, :text or nil (for both

--- a/modules/auxiliary/cloud/aws/enum_ssm.rb
+++ b/modules/auxiliary/cloud/aws/enum_ssm.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptInt.new('LIMIT', [false, 'Only return the specified number of results from each region']),
         OptString.new('FILTER_EC2_ID', [false, 'Look for specific EC2 instance ID']),
-        OptString.new('REGION', [true, 'AWS Region (eg. "us-west-2")']),
+        OptString.new('REGION', [true, 'AWS Region (e.g. "us-west-2")']),
         OptString.new('ACCESS_KEY_ID', [true, 'AWS Access Key ID (eg. "AKIAXXXXXXXXXXXXXXXX")', '']),
         OptString.new('SECRET_ACCESS_KEY', [true, 'AWS Secret Access Key (eg. "CA1+XXXXXXXXXXXXXXXXXXXXXX6aYDHHCBuLuV79")', ''])
       ]

--- a/modules/auxiliary/cloud/aws/enum_ssm.rb
+++ b/modules/auxiliary/cloud/aws/enum_ssm.rb
@@ -90,8 +90,9 @@ class MetasploitModule < Msf::Auxiliary
       }
     end
 
+    inv_params[:max_results] = datastore['LIMIT'] if datastore['LIMIT']
+
     ssm_ec2 = client.get_inventory(inv_params).entities.map { |e| e.data['AWS:InstanceInformation'].content }.flatten
-    ssm_ec2 = ssm_ec2[0...datastore['LIMIT']] if datastore['LIMIT']
     ssm_ec2.each do |ssm_host|
       report_host(
         host: ssm_host['IpAddress'],


### PR DESCRIPTION
This implements the changes to address the PR feedback from @adfoster-r7.

Main changes include:

* Windows sessions using Powershell are no longer compatible with *any* post modules or the upload/download meta-shell commands
* The Linux PTY downgrade issues have been addressed so that the session stays working as intended when the user cancels the abort operation and the processes are cleaned up.
* The filtering was all removed. It wasn't necessary, was incomplete and the `post/test/file` and `post/test/cmd_exec` tests all still pass for Linux. No tests can run for Windows because of point 1.
* Module docs were added.